### PR TITLE
S44 CI: score D-6 coverage from merged DA: lines, not the double-counted LF:/LH: summary

### DIFF
--- a/audit/ci/s44-coverage-metric-rebaseline.md
+++ b/audit/ci/s44-coverage-metric-rebaseline.md
@@ -145,9 +145,28 @@ pass and fail. The gate is non-vacuous.
 ## 6. What this does NOT fix — stated plainly
 
 The correction raises the *level*, not the *variance*. Run-to-run jitter of ~0.6 pp is still
-present (h2_proxy reads 80.96 / 81.57 / 81.52 across the three samples), and its source —
-almost certainly timing-dependent branches taken unevenly between runs — was **not**
-investigated here.
+present (h2_proxy reads 80.96 / 81.57 / 81.52 across the three samples), and its source is
+**still unexplained**.
+
+One obvious explanation was tested and **REFUTED**. The coverage job runs
+`cargo llvm-cov nextest --ignore-run-fail`, so a flaking test still counts as executed-but-
+failed and its lines could plausibly drop out of the profile — and there is a known flake
+named for this exact job and module (CF-S37-D6-H2PROXY-FLAKY). The data says otherwise:
+
+| run | tests failed inside the coverage run | h2_proxy (old metric) |
+|---|---:|---:|
+| 30745595161 (RED) | **0** — 1565/1565 passed | **79.65%** (lowest) |
+| 30749813681 (green) | **2** failed | 80.23% |
+| 30751410142 (green) | 0 — 1565/1565 passed | 80.13% |
+
+The run with *zero* failures produced the *lowest* coverage, and the run with two failures
+produced the highest. The correlation runs opposite to the hypothesis, so flaky test
+failures are not the mechanism. Do not re-chase this one.
+
+Remaining candidates, untested: nondeterministic scheduling across the two instantiations,
+llvm-cov profile-merge races under `--ignore-run-fail`, or genuinely timing-dependent
+branches. Any future attempt should start by diffing the per-line `DA:` sets of two runs to
+see *which* lines move, rather than reasoning from totals.
 
 So `h2_proxy.rs` remains the tightest hot-path module. It now sits ~1.0–1.6 pp above the
 floor instead of straddling it, which is a real margin rather than a coin flip, but it is

--- a/audit/ci/s44-coverage-metric-rebaseline.md
+++ b/audit/ci/s44-coverage-metric-rebaseline.md
@@ -1,0 +1,178 @@
+# S44 — D-6 coverage metric correction + 31-module re-baseline
+
+**Date:** 2026-08-02 · **Status:** implemented, owner-approved option (a)
+**Gate:** `scripts/ci/coverage-check.sh` (D-6, per-module hot-path ≥ 80% lines)
+**Predecessor:** `audit/ci/s43-h2proxy-coverage-dual-instantiation.md` (diagnosis)
+
+Owner ruling: **(a) fix the metric, with an explicit re-baseline of all 31 modules so the
+change is provably a correction and not a relaxation.** This is that re-baseline.
+
+---
+
+## 1. The problem, re-measured
+
+S43 diagnosed the cause correctly but had only four samples. Two more exist now:
+
+| run | h2_proxy.rs (old metric) | gate |
+|---|---:|---|
+| 28334977156 (artifact 7938582116) | 79.60% | RED |
+| 28334977156 (artifact 7938395373) | 79.70% | RED |
+| 28336426614 | 80.18% | green |
+| 30745595161 | 79.65% | RED |
+| 30749813681 | 80.23% | green |
+| 30751410142 | 80.13% | green |
+
+**3 RED / 3 green on effectively identical production source** — a coin flip. This corrects
+two earlier records: the handoff called it "~1 run in 4" red; S43 called it "three of four
+samples fail". With six samples it is ~50/50. `main` was green at handoff by luck.
+
+## 2. Root cause — confirmed independently, not inherited
+
+Re-verified from the RED artifact (`30745595161`), not from the S43 write-up:
+
+```
+h2_proxy.rs — SF: records for this file : 1
+  declared LF/LH            : 1887/1503  -> 79.65%   <- what the gate read
+  distinct DA: line numbers : 1780, hit 1441 -> 80.96%
+  FN: entries               : 596
+```
+
+107 phantom lines. The 596 `FN:` entries split across two crate disambiguators:
+
+| instantiation | FN: entries |
+|---|---:|
+| `CsdExPruU9iqX_5lb_l7` | 421 |
+| `CsbnMibX7jh97_5lb_l7` | 175 |
+
+and `handle_inner` shows `FNDA:597` under `CsdExPruU9iqX` — the real-wire build — while the
+`CsbnMibX7jh97` (lib-unit-test) copy cannot reach the request hot path at all, because
+`hyper::body::Incoming` has no public constructor. llvm-cov merges both instantiations into
+one `SF:` record; the `LF:`/`LH:` **summary** double-counts shared lines, the per-line `DA:`
+records do not. The unreachable copy's unhit lines were scored as genuine misses.
+
+**This is systemic, not an h2_proxy quirk: 29 of the hot-path modules are dual-instantiated.**
+h2_proxy was simply the only one sitting on the boundary, so it was the only one that flipped
+the gate.
+
+## 3. The fix
+
+Score from **merged `DA:` records**: each source line counted once, hit if **any**
+instantiation executed it. Threshold stays 80.0%. Patterns unchanged. The single named
+carve-out (`lb-l4-xdp/src/loader.rs`) is unchanged. Nothing is exempted or waived.
+
+Two latent defects were fixed in passing:
+
+- the old parser did `files[cur] = …` per record, so **multiple `SF:` records for one file
+  were last-record-wins**; the new one merges them;
+- the obvious way to write the merge — `if cnt > d.get(ln, 0): d[ln] = cnt` — is a trap:
+  `0 > 0` is False, so a line hit by **no** instantiation is never inserted and silently
+  leaves the *denominator*, scoring **every file at 100%**. Caught during verification
+  because the expected value (80.96%) was known in advance; a pass/fail-only check would
+  have shipped it green. The code uses `d[ln] = max(d.get(ln, 0), cnt)` and says why.
+
+## 4. Re-baseline — all 31 hot-path modules (sample: RED run 30745595161)
+
+| module | old (LF/LH) | new (DA) | delta | dual-inst |
+|---|---:|---:|---:|---|
+| `lb-balancer/src/ewma.rs` | 95.38% | 95.38% | +0.00 | — |
+| `lb-balancer/src/least_connections.rs` | 100.00% | 100.00% | +0.00 | — |
+| `lb-balancer/src/least_request.rs` | 100.00% | 100.00% | +0.00 | — |
+| `lb-balancer/src/lib.rs` | 100.00% | 100.00% | +0.00 | — |
+| `lb-balancer/src/maglev.rs` | 92.75% | 93.28% | +0.53 | +4 |
+| `lb-balancer/src/random.rs` | 86.21% | 85.71% | **-0.49** | +1 |
+| `lb-balancer/src/ring_hash.rs` | 92.00% | 92.62% | +0.62 | +3 |
+| `lb-balancer/src/round_robin.rs` | 100.00% | 100.00% | +0.00 | +1 |
+| `lb-balancer/src/session_affinity.rs` | 97.78% | 97.67% | **-0.10** | +2 |
+| `lb-balancer/src/weighted_random.rs` | 87.80% | 87.50% | **-0.30** | +1 |
+| `lb-balancer/src/weighted_round_robin.rs` | 92.55% | 92.31% | **-0.25** | +3 |
+| `lb-l4-xdp/src/stats_export.rs` | 83.33% | 84.51% | +1.17 | +8 |
+| `lb-l7/src/h1_proxy.rs` | 85.23% | 86.64% | +1.41 | +93 |
+| `lb-l7/src/h1_to_h1.rs` | 91.95% | 91.36% | **-0.60** | +6 |
+| `lb-l7/src/h1_to_h2.rs` | 92.93% | 92.31% | **-0.62** | +8 |
+| `lb-l7/src/h1_to_h3.rs` | 96.97% | 96.70% | **-0.27** | +8 |
+| `lb-l7/src/h2_proxy.rs` | 79.65% | 80.96% | +1.30 | +107 |
+| `lb-l7/src/h2_to_h1.rs` | 90.97% | 91.72% | +0.76 | +10 |
+| `lb-l7/src/h2_to_h2.rs` | 100.00% | 100.00% | +0.00 | +2 |
+| `lb-l7/src/h2_to_h3.rs` | 100.00% | 100.00% | +0.00 | +2 |
+| `lb-l7/src/h3_to_h1.rs` | 95.45% | 95.16% | **-0.29** | +4 |
+| `lb-l7/src/h3_to_h2.rs` | 100.00% | 100.00% | +0.00 | +2 |
+| `lb-l7/src/h3_to_h3.rs` | 100.00% | 100.00% | +0.00 | +2 |
+| `lb-observability/src/admin_http.rs` | 86.87% | 91.80% | +4.93 | +15 |
+| `lb-quic/src/conn_actor.rs` | 85.01% | 84.79% | **-0.21** | +20 |
+| `lb-quic/src/listener.rs` | 87.06% | 87.13% | +0.07 | +6 |
+| `lb-security/src/conn_gate.rs` | 91.14% | 90.91% | **-0.23** | +2 |
+| `lb-security/src/hooks.rs` | 96.84% | 96.84% | +0.00 | — |
+| `lb-security/src/smuggle.rs` | 98.97% | 98.94% | **-0.03** | +3 |
+| `lb-security/src/ticket.rs` | 84.41% | 85.98% | +1.57 | +14 |
+| `lb-security/src/watchdog.rs` | 95.48% | 95.45% | **-0.03** | +1 |
+
+**31 modules — 9 up, 12 DOWN, 10 unchanged. 0 below 80% under the corrected metric.**
+
+### Why this proves it is a correction, not a relaxation
+
+**More modules got stricter than looser.** A relaxation is a one-way ratchet — it can only
+move numbers up. This moves 12 modules *down*, because double-counted **hit** lines are
+removed from the numerator just as double-counted misses are removed from the denominator.
+The gate got *harder* on `random.rs`, `conn_gate.rs`, `conn_actor.rs`, and nine others, and
+they still pass on their own merits. The threshold never moved.
+
+## 5. Verification
+
+Gate re-run against all three real artifacts — every value matches an independently written
+scorer (`rebaseline.py`), not the gate's own output:
+
+| sample | h2_proxy old → new | gate |
+|---|---|---|
+| red 30745595161 | 79.65% → **80.96%** | exit 0 |
+| green 30749813681 | 80.23% → **81.57%** | exit 0 |
+| green 30751410142 | 80.13% → **81.52%** | exit 0 |
+
+**Load-bearing negative controls** — the gate must still fail when coverage genuinely drops,
+or the "fix" is just a green light:
+
+| control | expectation | result |
+|---|---|---|
+| NC1 — zero 576 of h2_proxy's 1441 hit lines | RED | 48.54%, **exit 1** ✅ |
+| NC2a — 1424/1780 hit (exactly 80.00%) | pass | 80.00%, exit 0 ✅ |
+| NC2b — 1423/1780 hit (79.94%) | RED | 79.94%, **exit 1** ✅ |
+| NC3a — all paths renamed, no pattern matches | fail closed | **exit 1** ✅ |
+| NC3b — empty LCOV | fail closed | **exit 1** ✅ |
+| NC4 — carve-outs | exactly 1, `loader.rs` | ✅ |
+
+NC2 shows **single-line discrimination at the floor**: one line is the difference between
+pass and fail. The gate is non-vacuous.
+
+## 6. What this does NOT fix — stated plainly
+
+The correction raises the *level*, not the *variance*. Run-to-run jitter of ~0.6 pp is still
+present (h2_proxy reads 80.96 / 81.57 / 81.52 across the three samples), and its source —
+almost certainly timing-dependent branches taken unevenly between runs — was **not**
+investigated here.
+
+So `h2_proxy.rs` remains the tightest hot-path module. It now sits ~1.0–1.6 pp above the
+floor instead of straddling it, which is a real margin rather than a coin flip, but it is
+**not** a comfortable one. If it drifts down again the honest fix is real test coverage
+(S43 option (c)) — the SNI-mismatch, watchdog, and underscore-policy arms — not another
+metric change.
+
+Two of those arms are worth noting as *product* gaps rather than test gaps:
+`HeaderUnderscorePolicy::Drop` (lines 1120-1135) is uncovered because the binary never calls
+`with_header_underscore_policy` — assessment gap **G7**, an inert knob. Covering it means
+wiring it, not writing a test for dead code.
+
+## 7. Effect on branch protection
+
+With this landed, `Coverage (per-module hot-path >= 80%)` is safe to add to the required
+checks in `audit/release/owner-actions.md` §1. Before it, requiring that check would have
+blocked roughly half of all PRs on a measurement artifact.
+
+## 8. Reproduce
+
+```sh
+gh api repos/:owner/:repo/actions/runs/30745595161/artifacts -q '.artifacts[].id'
+gh api repos/:owner/:repo/actions/artifacts/8832879049/zip > a.zip && unzip -q a.zip -d red
+bash scripts/ci/coverage-check.sh red/coverage.lcov     # exit 0, h2_proxy 80.96%
+git stash list  # (none — no stash used; R9)
+git show HEAD~1:scripts/ci/coverage-check.sh > /tmp/old.sh
+bash /tmp/old.sh red/coverage.lcov                      # exit 1, h2_proxy 79.65%
+```

--- a/audit/ci/s44-grpc-h3-te-trailer-hang.md
+++ b/audit/ci/s44-grpc-h3-te-trailer-hang.md
@@ -1,0 +1,161 @@
+# CF-S44-GRPC-H3-TE-HANG — `grpc_h3_without_te_header_still_delivers_trailer` hangs indefinitely
+
+**Date:** 2026-08-02 · **Status:** OPEN — found, attributed, **not fixed**
+**Severity:** CI-infrastructure. Burns a full 6-hour runner job; does **not** fail loudly.
+**First observed:** run `30755744744`, job `91517507600` (Coverage), branch `s44-coverage-metric`.
+
+---
+
+## 1. What happened
+
+The Coverage job ran for **5+ hours** with no progress and had to be cancelled manually. It
+would otherwise have sat until GitHub's 6-hour job timeout.
+
+nextest's own escalating SLOW markers name the test:
+
+```
+SLOW [>17460.000s] (─────────) lb-quic::grpc_h3_e2e grpc_h3_without_te_header_still_delivers_trailer
+SLOW [>17520.000s] ...
+SLOW [>17940.000s] (─────────) lb-quic::grpc_h3_e2e grpc_h3_without_te_header_still_delivers_trailer
+```
+
+and the orphan-process sweep on cancellation confirms what was still alive:
+
+```
+Terminate orphan process: pid (3056)  (cargo-llvm-cov)
+Terminate orphan process: pid (8445)  (cargo-nextest)
+Terminate orphan process: pid (12606) (grpc_h3_e2e-ee1b7dc6f6c6ee7e)
+```
+
+**1564 of 1565 tests completed.** This one test never returned — ~17,940 s and counting when
+killed. `Starting 1565 tests across 234 binaries` at 16:09:19Z; cancelled 21:11:34Z.
+
+## 2. This is a HANG, not slowness
+
+`crates/lb-quic/tests/grpc_h3_e2e.rs:960` sets the test's own budget:
+
+```rust
+const OVERALL: Duration = Duration::from_secs(20);
+```
+
+The test ran **~900× that budget**. Whatever the mechanism, the 20 s deadline did not bound it.
+
+## 3. Not caused by the S44 coverage change
+
+- The coverage-metric change is in `scripts/ci/coverage-check.sh`, which runs in the **next**
+  workflow step (`Enforce per-module hot-path threshold`) — still `pending` when the job was
+  cancelled. It never executed.
+- The change is a pure LCOV text parser. It cannot affect a QUIC test binary.
+- The same test **passed** on runs `30749813681` and `30751410142`, which completed all 1565
+  tests in ~343 s and ~372 s respectively.
+
+Therefore: **pre-existing and intermittent**, surfaced here for the first time.
+
+## 4. Two candidate mechanisms — not yet distinguished
+
+Both are consistent with the evidence; the log alone cannot separate them, and **neither has
+been proven**. Do not treat either as the cause without measurement.
+
+**(a) Blocked on the suite serial guard.** Every test in this binary opens with
+
+```rust
+macro_rules! serial_guard {
+    () => { let _suite_serial = SUITE_SERIAL.lock().await; };   // line 75-79
+}
+```
+
+An `await` on an async mutex with **no timeout**. If an earlier test in the binary leaked a
+task or aborted while holding the guard, every later test blocks here forever — and nextest
+would still show the test as "started", exactly as observed.
+
+**(b) The deadline is not enforced on every await path.** `drive_grpc_h3_core` computes
+
+```rust
+let deadline = tokio::time::Instant::now() + overall;
+```
+
+A deadline checked at loop boundaries does not bound an inner await that never resolves
+(QUIC handshake, backend accept, response read). Setup that runs *before* the driver —
+`spawn_h2_grpc_backend`, `start_h3_listener_h2` — is outside the budget entirely.
+
+Next step to distinguish: reproduce under `--test-threads=1` with a `RUST_LOG` trace, or attach
+to the wedged binary and dump task backtraces. Whichever it is, **the structural problem stands
+on its own**: an untimed `lock().await` in a shared test harness means one stuck test wedges
+the entire binary for the full 6-hour job limit.
+
+## 4b. Second observation — the hang is intermittent, and the suite is broadly fragile
+
+The job was re-run on the identical SHA (`6c81222f`). Result: **16/16 green in 986 s**, and the
+hanging test passed in **0.100 s**:
+
+```
+PASS [   0.100s] (1259/1565) lb-quic::grpc_h3_e2e grpc_h3_without_te_header_still_delivers_trailer
+```
+
+So the hang is **intermittent**, not deterministic — one occurrence in three observed runs.
+
+But the same re-run failed a *different* test in the *same* binary, also about trailers:
+
+```
+FAIL [   0.232s] (1256/1565) lb-quic::grpc_h3_e2e grpc_h3_trailer_survives_all_response_sizes
+thread '...' panicked at crates/lb-quic/tests/grpc_h3_e2e.rs:1242:9:
+assertion `left == right` failed: sz=262144
+  left: Some(502)
+ right: Some(200)
+```
+
+A **502 instead of 200 at a 256 KiB response**. This is **not** on the known-flake list
+(CF-FCAP1-FLAKE, CF-SATURATION-1, CF-S35-T5-FLAKE, CF-S37-D6-H2PROXY-FLAKY,
+CF-S38-RELOAD-BOOT-FLAKE) — it is a new observation.
+
+Two different trailer tests in `grpc_h3_e2e` misbehaved in two consecutive instrumented runs
+(one hang, one 502). The uninstrumented `Test` job passed both times. The common factor is the
+llvm-cov instrumented build, which is substantially slower — consistent with
+[[gate-saturation-test-fragility]] ("gate saturation exposes tight test-backend timeouts as
+flakes").
+
+**That mechanism is a hypothesis, not a finding.** Per R2 a flake is classified by *proven*
+mechanism from captured output, and no one has proven this one. What is established: the
+symptom, the exact assertion, the response size, and that both occurrences are
+instrumentation-only. Whether the 502 is a tight test-backend timeout or a genuine
+gateway-side failure on large H3 responses is **open** — and the second possibility is a
+product bug, not a test bug, so it should not be assumed away.
+
+## 5. Why this is worse than a failing test
+
+- **`--ignore-run-fail`.** The Coverage job runs
+  `cargo llvm-cov nextest --workspace --all-features --ignore-run-fail` precisely so a flake
+  does not lose the coverage measurement. A *hang* is not a failure — the flag cannot help,
+  and the job neither fails nor completes. It just burns runner time silently.
+- **Instrumented builds are slower**, which is exactly the condition that exposes
+  timing-dependent deadlocks. The uninstrumented `Test` job **passed** in the same run — so
+  the Test lane is not a reliable detector for this.
+- **No job-level timeout.** No `timeout-minutes:` is set on the Coverage job, so the ceiling is
+  GitHub's 6-hour default.
+
+## 6. Recommended actions (not taken here)
+
+1. **Cheap and immediate — add `timeout-minutes:` to the CI jobs.** The Coverage job's test
+   step has historically finished in ~6 minutes; a 45–60 minute cap turns a silent 6-hour burn
+   into a fast, loud red. This is a containment measure, not a fix, and it should not be
+   confused with one.
+2. **Bound the serial guard.** Wrap `SUITE_SERIAL.lock()` in a `tokio::time::timeout` and panic
+   with a clear message on expiry, so the *next* occurrence names the culprit instead of
+   hanging.
+3. **Bound the test itself** — wrap the whole body in `tokio::time::timeout(OVERALL * 2, …)` so
+   `OVERALL` actually means something end-to-end, including setup.
+4. **Then** find the real mechanism. Items 1–3 stop the bleeding; they do not explain it.
+
+Do **not** close this by deleting or `#[ignore]`-ing the test — it covers a real protocol
+behaviour (trailer delivery without `te: trailers`), and an intermittent hang in a QUIC/H3
+path may well indicate a genuine product-side deadlock rather than a test artifact. That
+question is open.
+
+## 7. Reproduce / re-observe
+
+```sh
+gh api repos/:owner/:repo/actions/jobs/91517507600/logs \
+  | sed 's/\x1b\[[0-9;]*m//g' | grep -E "SLOW|Terminate orphan"
+cargo nextest run -p lb-quic --test grpc_h3_e2e \
+  grpc_h3_without_te_header_still_delivers_trailer --test-threads=1
+```

--- a/audit/release/owner-actions.md
+++ b/audit/release/owner-actions.md
@@ -1,0 +1,216 @@
+# Owner actions — copy-paste pack
+
+**Prepared:** 2026-08-02 · **Against:** `main` @ `eb00081d` · **Verified from source**, not from docs.
+
+Two things in this repo can only be done with owner credentials. An agent cannot do either.
+Everything else in the program is defended by gates that are **not currently enforced**.
+
+---
+
+## 1. Branch protection — currently NONE
+
+Verified at handoff:
+
+```
+$ gh api repos/:owner/:repo/branches/main/protection
+{"message":"Branch not protected","status":"404"}
+$ gh api repos/:owner/:repo/rulesets
+[]
+```
+
+**Anyone with write access can push directly to `main`, and zero checks are required.**
+The previous session pushed straight to `main` unopposed. Secret scanning and push
+protection are also off.
+
+### The 16 required checks
+
+These are the exact job names from the green run `30751410142`, cross-checked against
+`.github/workflows/ci.yml`. They must match character-for-character or the check will
+never be satisfied and PRs will hang forever.
+
+```
+Format
+Check
+Clippy
+Panic Freedom Audit
+Doc Lint
+Test
+MSRV (1.88)
+Fuzz Smoke Test
+Release Build
+Security Audit
+cargo-deny (licenses/advisories/bans/sources)
+Coverage (per-module hot-path >= 80%)
+Conformance (h2spec --strict + h3spec)
+Chaos Attack Suite
+Container Image (build + serve smoke + trivy)
+XDP Verifier Smoke (runner kernel)
+```
+
+> ⚠️ **Read §3 before requiring `Coverage (per-module hot-path >= 80%)`.** That gate is a
+> coin-flip today (3 red / 3 green on identical source). If you require it as-is, roughly
+> half of all PRs will be blocked by a measurement artifact rather than by a real
+> regression. Either fix the metric first, or add it to the required list afterwards.
+
+### Apply it
+
+```sh
+cat > /tmp/protection.json <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Format",
+      "Check",
+      "Clippy",
+      "Panic Freedom Audit",
+      "Doc Lint",
+      "Test",
+      "MSRV (1.88)",
+      "Fuzz Smoke Test",
+      "Release Build",
+      "Security Audit",
+      "cargo-deny (licenses/advisories/bans/sources)",
+      "Conformance (h2spec --strict + h3spec)",
+      "Chaos Attack Suite",
+      "Container Image (build + serve smoke + trivy)",
+      "XDP Verifier Smoke (runner kernel)"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_last_push_approval": true
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+
+gh api -X PUT repos/shieldblaze/ExpressGateway/branches/main/protection \
+  -H "Accept: application/vnd.github+json" --input /tmp/protection.json
+```
+
+Notes on the choices above — change any of these if you disagree:
+
+- `enforce_admins: true` — without it, admins bypass everything and the gate is decorative.
+- `strict: true` — branches must be up to date with `main` before merging. Costs a re-run
+  on busy days; catches semantic conflicts that a clean textual merge hides.
+- `required_linear_history: true` — **compatible with the repo's squash-only convention**,
+  but note R11 promotes with `--no-ff` merge commits. If you keep promoting with `--no-ff`,
+  set this to `false` or the promote will be rejected.
+- `Coverage (...)` is **deliberately omitted** from the list above pending §3.
+
+### Also worth enabling (separate, one click each in Settings → Code security)
+
+- Secret scanning + **push protection** (currently disabled).
+- Dependabot alerts (already producing PRs, but confirm alerts are on).
+
+### Verify it took
+
+```sh
+gh api repos/shieldblaze/ExpressGateway/branches/main/protection \
+  -q '.required_status_checks.contexts, .enforce_admins.enabled'
+```
+
+---
+
+## 2. Release soak gate — un-armed
+
+`.github/workflows/release.yml` provisions an EC2 box, runs the soak, reads a verdict, and
+tears the box down. It cannot run: **none of its inputs are set.** The only repo secrets are
+`MONGO_CONNECTION_STRING` and `ZOOKEEPER_ADDRESS`, both from 2022 and both unrelated —
+they look like leftovers from the pre-Rust project and are probably worth deleting.
+
+Exact names, read from `release.yml:53-63` (all are `SOAK_`-prefixed):
+
+**Secret (1)**
+
+| name | line | notes |
+|---|---|---|
+| `SOAK_AWS_ROLE_ARN` | 53 | OIDC role to assume; needs a trust policy for this repo |
+
+**Variables (7)**
+
+| name | line | notes |
+|---|---|---|
+| `SOAK_REGION` | 54, 57 | also used for the AWS credential config step |
+| `SOAK_AMI` | 58 | Ubuntu AMI in that region |
+| `SOAK_SUBNET_ID` | 59 | must have egress for the S3 upload |
+| `SOAK_SECURITY_GROUP_ID` | 60 | |
+| `SOAK_IAM_INSTANCE_PROFILE` | 61 | instance needs S3 write to the bucket below |
+| `SOAK_S3_BUCKET` | 62 | soak artifacts/verdict land here |
+| `SOAK_INSTANCE_TYPE` | 63 | **optional**, defaults to `c6a.2xlarge` |
+
+```sh
+R=shieldblaze/ExpressGateway
+gh secret set   SOAK_AWS_ROLE_ARN         -R $R   # prompts, not echoed
+gh variable set SOAK_REGION               -R $R --body "us-east-1"
+gh variable set SOAK_AMI                  -R $R --body "ami-…"
+gh variable set SOAK_SUBNET_ID            -R $R --body "subnet-…"
+gh variable set SOAK_SECURITY_GROUP_ID    -R $R --body "sg-…"
+gh variable set SOAK_IAM_INSTANCE_PROFILE -R $R --body "…"
+gh variable set SOAK_S3_BUCKET            -R $R --body "…"
+```
+
+### Then prove it end-to-end before trusting it
+
+The whole point of this gate is that it tears the box down. An untested teardown path is a
+standing bill. Do a `workflow_dispatch` dry-run and confirm all four stages:
+**provision → soak → verdict → teardown**, then check the console for a surviving instance.
+
+```sh
+gh workflow run release.yml -R $R
+gh run watch -R $R
+aws ec2 describe-instances --region "$SOAK_REGION" \
+  --filters "Name=instance-state-name,Values=running,stopped" \
+  --query 'Reservations[].Instances[].[InstanceId,Tags]'   # expect: none from the soak
+```
+
+---
+
+## 3. Coverage gate — needs a ruling, do not silently waive
+
+Full analysis: `audit/ci/s43-h2proxy-coverage-dual-instantiation.md`.
+Six samples now exist on effectively identical production source:
+
+| run | h2_proxy.rs | gate |
+|---|---|---|
+| 28334977156 (artifact 7938582116) | 79.60% | RED |
+| 28334977156 (artifact 7938395373) | 79.70% | RED |
+| 28336426614 | 80.18% | green |
+| 30745595161 | 79.65% | RED |
+| 30749813681 | 80.23% | green |
+| 30751410142 | 80.13% | green |
+
+**3 red / 3 green — a coin flip**, not the "~1 in 4" the handoff records, and not the
+"3 of 4 fail" the S43 doc records (it had only the first four samples). Mean ≈ 79.92%,
+spread ≈ 0.6 pp, against a hard 80.00 floor. `main` is green today by luck.
+
+**Root cause is a measurement artifact, not thin tests.** `lb-l7` is compiled twice; llvm-cov
+merges both instantiations into one `SF:` record whose `LF:`/`LH:` summary (which the gate
+reads) double-counts lines, while the per-line `DA:` records do not. The second instantiation
+is the lib-unit-test build, which *structurally cannot* reach the request hot path —
+`hyper::body::Incoming` has no public constructor. Its unhit lines are counted as real misses.
+
+The options, unchanged from the S43 write-up — **(a) is the recommendation**:
+
+- **(a) Score from merged `DA:` records** instead of the `LF:`/`LH:` summary, so each source
+  line counts once. h2_proxy then reads **80.96%** and passes honestly. This is a
+  *correction* toward the charter's stated metric, not a loosening — every threshold stays
+  at 80%. Requires re-baselining all 31 modules and publishing a before/after table so it is
+  provably not a relaxation.
+- **(b)** De-duplicate the instantiations so only one build is measured. Cleanest in theory,
+  fiddly in practice.
+- **(c)** Add real-wire tests for the SNI / watchdog / underscore-policy paths. Real test
+  value, but does not touch the double-counting, and the uncovered arms need a
+  **non-loopback** bind, which is CI-fragile.
+- **(d)** Leave it. Honest, but keeps `main` red half the time on a number that is not
+  measuring what it claims.
+
+Whatever you choose: it should be a deliberate, documented gate change with the before/after
+table published — not folded silently into another PR.

--- a/scripts/ci/coverage-check.sh
+++ b/scripts/ci/coverage-check.sh
@@ -25,6 +25,34 @@
 #     LCOV paths are wrong); a single non-matching pattern is loud-warned so a
 #     legitimate rename surfaces without wedging the gate.
 #
+# METRIC CORRECTION (S44) — score merged DA: records, not the LF:/LH: summary.
+#   `lb-l7` (and 25 other modules) are compiled twice; llvm-cov merges both
+#   instantiations into ONE `SF:` record whose LF:/LH: summary counts shared
+#   source lines TWICE, while the per-line DA: records do not. For h2_proxy.rs
+#   the record declared LF:1887 while emitting only 1780 distinct DA: lines —
+#   107 phantom lines, and 596 FN: entries split across two crate
+#   disambiguators (CsdExPruU9iqX_5lb_l7 / CsbnMibX7jh97_5lb_l7). The second
+#   instantiation is the lib-unit-test build, which CANNOT reach the request
+#   hot path at all (`hyper::body::Incoming` has no public constructor), so its
+#   unhit lines were being scored as genuine misses. That put the gate on a
+#   coin flip: 3 RED / 3 green on byte-identical production source.
+#
+#   So: a source line is counted ONCE, and is "hit" if ANY instantiation
+#   executed it. This is the charter's stated metric ("per-module line
+#   coverage") measured correctly.
+#
+#   This is a CORRECTION, NOT a relaxation, and the evidence is that it moves
+#   numbers in BOTH directions — random.rs 86.21 -> 85.71, conn_gate.rs
+#   91.14 -> 90.91, conn_actor.rs 85.01 -> 84.79 all get STRICTER, because
+#   double-counted *hit* lines are removed from the numerator too. A loosening
+#   would only ever move numbers up. The 80% threshold is unchanged, no module
+#   is exempted, and no module falls below 80% under the corrected metric.
+#   Full 31-module before/after table: audit/ci/s44-coverage-metric-rebaseline.md
+#
+#   Records whose declared LF: exceeds their distinct DA: line count are
+#   reported as "dual-instantiated" so the artifact stays VISIBLE rather than
+#   silently drifting back.
+#
 # Usage: coverage-check.sh <coverage.lcov>
 
 set -uo pipefail
@@ -33,26 +61,47 @@ test -f "$LCOV" || { echo "::error::LCOV file $LCOV not found"; exit 1; }
 THRESHOLD=80.0
 
 python3 - "$LCOV" "$THRESHOLD" <<'PY'
-import re, sys
+import re, sys, collections
 
 lcov_path, threshold = sys.argv[1], float(sys.argv[2])
 
-# Parse LCOV: per record, SF:<file> ... LF:<found> LH:<hit> end_of_record.
-files = {}
+# Parse LCOV per-LINE (DA:<line>,<count>), merging every record and every
+# instantiation of a file. A source line is counted ONCE; it is "hit" if ANY
+# instantiation executed it. See the METRIC CORRECTION note in the header.
+# `declared_lf` is retained ONLY to surface dual-instantiation, never to score.
+lines_by_file = collections.defaultdict(dict)   # file -> {line_no: max_count}
+declared_lf = collections.Counter()             # file -> sum of LF: across records
 cur = None
-lf = lh = 0
 for line in open(lcov_path):
     line = line.strip()
     if line.startswith("SF:"):
-        cur, lf, lh = line[3:], 0, 0
-    elif line.startswith("LF:"):
-        lf = int(line[3:])
-    elif line.startswith("LH:"):
-        lh = int(line[3:])
-    elif line == "end_of_record" and cur is not None:
-        if lf > 0:
-            files[cur] = 100.0 * lh / lf
+        cur = line[3:]
+    elif line.startswith("LF:") and cur is not None:
+        declared_lf[cur] += int(line[3:])
+    elif line.startswith("DA:") and cur is not None:
+        # DA:<line>,<count>[,<checksum>]
+        parts = line[3:].split(",")
+        try:
+            ln, cnt = int(parts[0]), int(parts[1])
+        except (ValueError, IndexError):
+            continue
+        # ALWAYS assign: a line whose every instantiation reports 0 must still
+        # land in the dict, or it silently leaves the DENOMINATOR and every
+        # file scores 100%. (`if cnt > d.get(ln, 0)` is the trap — 0 > 0 is
+        # False, so never-executed lines would never be inserted at all.)
+        d = lines_by_file[cur]
+        d[ln] = max(d.get(ln, 0), cnt)
+    elif line == "end_of_record":
         cur = None
+
+files = {}
+dual = []
+for f, lns in lines_by_file.items():
+    if not lns:
+        continue
+    files[f] = 100.0 * sum(1 for c in lns.values() if c > 0) / len(lns)
+    if declared_lf[f] > len(lns):
+        dual.append((f, declared_lf[f], len(lns)))
 
 # Charter hot-path modules mapped to the CURRENT file layout. "bridges::*" =
 # the cross-protocol h*_to_h*.rs files; lb-balancer "* (all)" = every
@@ -85,8 +134,22 @@ for pat in REQUIRED:
         (below if p + 1e-9 < threshold else checked).append((n, p))
 
 print(f"D-6 per-module hot-path coverage gate (threshold {threshold:.0f}% lines)")
+print("  metric: merged DA: per-line (each source line counted once, hit if ANY "
+      "instantiation ran it)")
 print(f"  {len(checked)} hot-path modules passed, {len(below)} below, "
       f"{len(empty_pats)} pattern(s) unmatched")
+
+# Visibility, not a gate: report files llvm-cov emitted with more declared LF:
+# than distinct source lines. Scoring off LF:/LH: here would double-count them.
+dual_hot = sorted((f, lf, n) for f, lf, n in dual
+                  if any(hit(p, f) for p in REQUIRED) or hit(EXEMPT, f))
+if dual_hot:
+    print(f"  note: {len(dual_hot)} hot-path module(s) are dual-instantiated "
+          "(declared LF: > distinct source lines); scored once each:")
+    for f, lf, n in dual_hot[:6]:
+        print(f"        {f.split('crates/')[-1]:<40} LF:{lf} distinct:{n} (+{lf-n})")
+    if len(dual_hot) > 6:
+        print(f"        … and {len(dual_hot)-6} more")
 for n, p in sorted(checked):
     print(f"    OK     {p:6.2f}%  {n}")
 if exempt_hit:


### PR DESCRIPTION
## Problem

The D-6 coverage gate is a **coin flip** — 3 RED / 3 green on effectively identical production source:

| run | h2_proxy.rs | gate |
|---|---:|---|
| 28334977156 (art 7938582116) | 79.60% | RED |
| 28334977156 (art 7938395373) | 79.70% | RED |
| 28336426614 | 80.18% | green |
| 30745595161 | 79.65% | RED |
| 30749813681 | 80.23% | green |
| 30751410142 | 80.13% | green |

`main` is green today by luck. This also corrects two earlier records: the handoff called it "~1 run in 4" red, S43 called it "three of four samples fail" — with six samples it is ~50/50.

## Cause

Re-verified independently from the RED artifact rather than inherited from the S43 write-up. `lb-l7` is compiled twice and llvm-cov merges both instantiations into **one** `SF:` record whose `LF:`/`LH:` summary double-counts shared source lines:

```
h2_proxy.rs  declared LF/LH : 1887/1503  -> 79.65%   <- what the gate read
             distinct DA:   : 1780, hit 1441 -> 80.96%
             FN: entries    : 596  (421 CsdExPruU9iqX_5lb_l7 / 175 CsbnMibX7jh97_5lb_l7)
```

The second instantiation is the lib-unit-test build, which **cannot reach the request hot path at all** — `hyper::body::Incoming` has no public constructor — so its unhit lines were scored as genuine misses. This is systemic: **29 hot-path modules are dual-instantiated**; h2_proxy was just the only one sitting on the boundary.

## Fix

Score merged `DA:` records — each source line counted once, hit if **any** instantiation ran it. Threshold stays 80.0. Patterns unchanged. The single named `loader.rs` carve-out unchanged. Nothing waived or exempted.

## This is a correction, not a relaxation — and the re-baseline proves it

Of 31 hot-path modules: **9 up, 12 DOWN, 10 unchanged, 0 below 80%.**

A relaxation is a one-way ratchet — it cannot make `random.rs` (86.21→85.71), `conn_gate.rs` (91.14→90.91) or `conn_actor.rs` (85.01→84.79) **stricter**, which this does, because double-counted *hit* lines leave the numerator too. Full 31-row table in `audit/ci/s44-coverage-metric-rebaseline.md`.

## Two latent defects fixed in passing

- the old parser did `files[cur] = …` per record, so multiple `SF:` records for one file were **last-record-wins**;
- writing the merge as `if cnt > d.get(ln, 0)` is a trap — `0 > 0` is False, so a line hit by no instantiation never enters the dict, silently leaves the **denominator**, and every file scores **100%**. Caught only because the expected value (80.96%) was known in advance; a pass/fail-only check would have shipped it green.

## Verification

Every value cross-checked against an independently written scorer, not the gate's own output.

| sample | old → new | gate |
|---|---|---|
| red 30745595161 | 79.65% → **80.96%** | exit 0 |
| green 30749813681 | 80.23% → **81.57%** | exit 0 |
| green 30751410142 | 80.13% → **81.52%** | exit 0 |

**Load-bearing negative controls** — the gate must still fail when coverage genuinely drops:

| control | expect | result |
|---|---|---|
| zero 576 of 1441 hit lines | RED | 48.54%, exit 1 ✅ |
| 1424/1780 (exactly 80.00%) | pass | exit 0 ✅ |
| 1423/1780 (79.94%) | RED | exit 1 ✅ |
| all paths renamed | fail closed | exit 1 ✅ |
| empty LCOV | fail closed | exit 1 ✅ |
| carve-outs | exactly 1 | ✅ |

Single-line discrimination at the floor — the gate is non-vacuous.

## What this does NOT fix

The ~0.6 pp run-to-run **jitter** is untouched; only the level moves. `h2_proxy` now sits ~1.0–1.6 pp above the floor instead of straddling it — a real margin, not a comfortable one. If it drifts down again the honest fix is real coverage (S43 option (c)), not another metric change.

## Follow-on

With this landed, `Coverage (per-module hot-path >= 80%)` becomes safe to add to required status checks. Before it, requiring that check would have blocked ~half of all PRs on a measurement artifact. Owner copy-paste pack for branch protection + the `SOAK_*` values: `audit/release/owner-actions.md`.